### PR TITLE
capture init commit

### DIFF
--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
+	"github.com/pingcap/ticdc/pkg/regionspan"
 	"go.uber.org/zap"
 )
 
@@ -165,6 +166,10 @@ type TableOperation struct {
 	// if the operation is a add operation, BoundaryTs is start ts
 	BoundaryTs uint64 `json:"boundary_ts"`
 	Status     uint64 `json:"status,omitempty"`
+
+	TableID   TableID `json:"table-id"`
+	SpanStart []byte  `json:"span-start"`
+	SpanEnd   []byte  `json:"span-end"`
 }
 
 // TableProcessed returns whether the table has been processed by processor
@@ -216,6 +221,10 @@ func (w *TaskWorkload) Marshal() (string, error) {
 type TableReplicaInfo struct {
 	StartTs     Ts      `json:"start-ts"`
 	MarkTableID TableID `json:"mark-table-id"`
+
+	TableID   TableID `json:"table-id"`
+	SpanStart []byte  `json:"span-start"`
+	SpanEnd   []byte  `json:"span-end"`
 }
 
 // Clone clones a TableReplicaInfo
@@ -236,6 +245,9 @@ type TaskStatus struct {
 	ModRevision  int64                         `json:"-"`
 	// true means Operation record has been changed
 	Dirty bool `json:"-"`
+
+	KeySpans         map[KeySpanHash]*TableReplicaInfo `json:"key-spans"`
+	KeySpanOperation map[KeySpanHash]*TableOperation   `json:"key-span-operation"`
 }
 
 // String implements fmt.Stringer interface.
@@ -287,6 +299,31 @@ func (ts *TaskStatus) AddTable(id TableID, table *TableReplicaInfo, boundaryTs T
 		Delete:     false,
 		BoundaryTs: boundaryTs,
 		Status:     OperDispatched,
+	}
+}
+
+// AddKeySpan add the key span in KeySpanInfos and add a add key span operation.
+func (ts *TaskStatus) AddKeySpan(span regionspan.Span, info *TableReplicaInfo, boundaryTs Ts) {
+	hash := KeySpanHash(span.Hash())
+	if ts.KeySpans == nil {
+		ts.KeySpans = make(map[KeySpanHash]*TableReplicaInfo)
+	}
+	_, exist := ts.KeySpans[hash]
+	if exist {
+		return
+	}
+	ts.KeySpans[hash] = info
+	log.Info("add a key span", zap.Any("span", span), zap.Uint64("hash", hash), zap.Int64("tableId", info.TableID), zap.Uint64("boundaryTs", boundaryTs))
+	if ts.KeySpanOperation == nil {
+		ts.KeySpanOperation = make(map[KeySpanHash]*TableOperation)
+	}
+	ts.KeySpanOperation[hash] = &TableOperation{
+		Delete:     false,
+		BoundaryTs: boundaryTs,
+		Status:     OperDispatched,
+		TableID:    info.TableID,
+		SpanStart:  span.Start,
+		SpanEnd:    span.End,
 	}
 }
 
@@ -370,6 +407,9 @@ type ChangeFeedID = string
 
 // TableID is the ID of the table
 type TableID = int64
+
+// KeySpanHash is the hash of the key span
+type KeySpanHash = uint64
 
 // SchemaID is the ID of the schema
 type SchemaID = int64

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -358,7 +358,7 @@ func (c *changefeed) preflightCheck(captures map[model.CaptureID]*model.CaptureI
 
 	for captureID := range c.state.TaskPositions {
 		if _, exist := captures[captureID]; !exist {
-			c.state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			c.state.PatchTaskPosition(captureID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 				return nil, position != nil, nil
 			})
 			ok = false

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -179,7 +179,7 @@ func (c *changefeed) tick(ctx cdcContext.Context, state *orchestrator.Changefeed
 		// So we return here.
 		return nil
 	}
-	shouldUpdateState, err := c.scheduler.Tick(c.state, c.schema.AllPhysicalTables(), captures)
+	shouldUpdateState, err := c.scheduler.Tick(ctx, c.state, c.schema.AllPhysicalTables(), captures)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -145,7 +145,7 @@ func (s *changefeedSuite) TestPreCheck(c *check.C) {
 	state.PatchTaskStatus(offlineCaputreID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
 		return new(model.TaskStatus), true, nil
 	})
-	state.PatchTaskPosition(offlineCaputreID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(offlineCaputreID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		return new(model.TaskPosition), true, nil
 	})
 	state.PatchTaskWorkload(offlineCaputreID, func(workload model.TaskWorkload) (model.TaskWorkload, bool, error) {

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -231,7 +231,7 @@ func (m *feedStateManager) cleanUpInfos() {
 		})
 	}
 	for captureID := range m.state.TaskPositions {
-		m.state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+		m.state.PatchTaskPosition(captureID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return nil, position != nil, nil
 		})
 	}
@@ -251,7 +251,7 @@ func (m *feedStateManager) errorsReportedByProcessors() []*model.RunningError {
 			}
 			runningErrors[position.Error.Code] = position.Error
 			log.Error("processor report an error", zap.String("changefeedID", m.state.ID), zap.String("captureID", captureID), zap.Any("error", position.Error))
-			m.state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			m.state.PatchTaskPosition(captureID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 				if position == nil {
 					return nil, false, nil
 				}

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -146,7 +146,7 @@ func (s *feedStateManagerSuite) TestCleanUpInfos(c *check.C) {
 	state.PatchTaskStatus(ctx.GlobalVars().CaptureInfo.ID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
 		return &model.TaskStatus{}, true, nil
 	})
-	state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		return &model.TaskPosition{}, true, nil
 	})
 	state.PatchTaskWorkload(ctx.GlobalVars().CaptureInfo.ID, func(workload model.TaskWorkload) (model.TaskWorkload, bool, error) {
@@ -189,7 +189,7 @@ func (s *feedStateManagerSuite) TestHandleError(c *check.C) {
 	state.PatchTaskStatus(ctx.GlobalVars().CaptureInfo.ID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
 		return &model.TaskStatus{}, true, nil
 	})
-	state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		return &model.TaskPosition{Error: &model.RunningError{
 			Addr:    ctx.GlobalVars().CaptureInfo.AdvertiseAddr,
 			Code:    "[CDC:ErrEtcdSessionDone]",
@@ -208,7 +208,7 @@ func (s *feedStateManagerSuite) TestHandleError(c *check.C) {
 
 	// throw error more than history threshold to turn feed state into error
 	for i := 0; i < model.ErrorHistoryThreshold; i++ {
-		state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+		state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return &model.TaskPosition{Error: &model.RunningError{
 				Addr:    ctx.GlobalVars().CaptureInfo.AdvertiseAddr,
 				Code:    "[CDC:ErrEtcdSessionDone]",

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -236,7 +236,7 @@ func (o *Owner) cleanUpChangefeed(state *orchestrator.ChangefeedReactorState) {
 		})
 	}
 	for captureID := range state.TaskPositions {
-		state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+		state.PatchTaskPosition(captureID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return nil, position != nil, nil
 		})
 	}

--- a/cdc/owner/scheduler.go
+++ b/cdc/owner/scheduler.go
@@ -14,6 +14,12 @@
 package owner
 
 import (
+	"bytes"
+	"context"
+	cdcContext "github.com/pingcap/ticdc/pkg/context"
+	"github.com/pingcap/ticdc/pkg/regionspan"
+	"github.com/tikv/client-go/v2/tikv"
+	pd "github.com/tikv/pd/client"
 	"math"
 
 	"github.com/pingcap/errors"
@@ -22,7 +28,6 @@ import (
 	"github.com/pingcap/ticdc/cdc/model"
 	cerror "github.com/pingcap/ticdc/pkg/errors"
 	"github.com/pingcap/ticdc/pkg/orchestrator"
-	"github.com/pingcap/ticdc/pkg/regionspan"
 	"go.uber.org/zap"
 )
 
@@ -69,7 +74,7 @@ func newScheduler() *scheduler {
 // Tick is the main function of scheduler. It dispatches tables to captures and handles move-table and rebalance events.
 // Tick returns a bool representing whether the changefeed's state can be updated in this tick.
 // The state can be updated only if all the tables which should be listened to have been dispatched to captures and no operations have been sent to captures in this tick.
-func (s *scheduler) Tick(state *orchestrator.ChangefeedReactorState, currentTables []model.TableID, captures map[model.CaptureID]*model.CaptureInfo) (shouldUpdateState bool, err error) {
+func (s *scheduler) Tick(ctx cdcContext.Context, state *orchestrator.ChangefeedReactorState, currentTables []model.TableID, captures map[model.CaptureID]*model.CaptureInfo) (shouldUpdateState bool, err error) {
 	s.state = state
 	s.currentTables = currentTables
 	s.captures = captures
@@ -79,7 +84,7 @@ func (s *scheduler) Tick(state *orchestrator.ChangefeedReactorState, currentTabl
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	pendingJob = s.splitPendingJobsToKeySpans(pendingJob)
+	pendingJob = s.splitPendingJobsToKeySpans(ctx, pendingJob)
 	s.dispatchToTargetCaptures(pendingJob)
 	if len(pendingJob) != 0 {
 		log.Debug("scheduler:generated pending job to be executed", zap.Any("pendingJob", pendingJob))
@@ -240,19 +245,28 @@ func (s *scheduler) dispatchToTargetCaptures(pendingJobs []*schedulerJob) {
 	}
 }
 
-func (s *scheduler) splitPendingJobsToKeySpans(pendingJobs []*schedulerJob) []*schedulerJob {
+func (s *scheduler) splitPendingJobsToKeySpans(ctx cdcContext.Context, pendingJobs []*schedulerJob) []*schedulerJob {
 	// TODO(tiool): real scheduler algorithm
+	pdClient := ctx.GlobalVars().PDClient
 	newJobs := make([]*schedulerJob, 0, len(pendingJobs))
 	for _, job := range pendingJobs {
-		if job.Tp == schedulerJobTypeAddTable {
-			newJobs = append(newJobs, &schedulerJob{
-				Tp:         job.Tp,
-				TableID:    job.TableID,
-				BoundaryTs: job.BoundaryTs,
-				Span:       regionspan.GetTableSpan(job.TableID),
-			})
-		} else {
-			newJobs = append(newJobs, job) // TODO(tiool): delete table job
+		tableID := job.TableID
+		regions, _ := GetRegionsByTableID(context.Background(), tableID, pdClient)
+		tableSpan := regionspan.GetTableSpan(tableID)
+		capture2Span := s.divideRegionsByCaptureNum(regions, tableSpan)
+		for captureID, span := range capture2Span {
+			if job.Tp == schedulerJobTypeAddTable {
+				newJobs = append(newJobs, &schedulerJob{
+					Tp:            job.Tp,
+					TableID:       job.TableID,
+					BoundaryTs:    job.BoundaryTs,
+					Span:          regionspan.Span(span),
+					TargetCapture: captureID,
+				})
+			} else {
+				newJobs = append(newJobs, job) // TODO(tiool): delete table job
+			}
+
 		}
 	}
 	return newJobs
@@ -425,4 +439,149 @@ func (s *scheduler) rebalanceByTableNum() (shouldUpdateState bool) {
 		}
 	}
 	return
+}
+
+func (s *scheduler) rebalanceByRegionNum(ctx cdcContext.Context) (shouldUpdateState bool) {
+	totalTableNum := len(s.currentTables)
+	captureNum := len(s.captures)
+	shouldUpdateState = true
+	pdClient := ctx.GlobalVars().PDClient
+
+	log.Info("Start rebalancing",
+		zap.String("changefeed", s.state.ID),
+		zap.Int("table-num", totalTableNum),
+		zap.Int("capture-num", captureNum),
+	)
+
+	for _, tableID := range s.currentTables {
+		log.Info("currentTables", zap.Int64("tableID", tableID))
+		tableID := tableID
+		regions, _ := GetRegionsByTableID(context.Background(), tableID, pdClient)
+		tableSpan := regionspan.GetTableSpan(tableID)
+		capture2Span := s.divideRegionsByCaptureNum(regions, tableSpan)
+		globalCheckpointTs := s.state.Status.CheckpointTs
+
+		for captureID, taskStatus := range s.state.TaskStatuses {
+			if span, exist := capture2Span[captureID]; exist {
+				if taskStatus.Tables == nil {
+					taskStatus.Tables = make(map[model.TableID]*model.TableReplicaInfo)
+				}
+				if taskStatus.Tables[tableID] != nil &&
+					bytes.Equal(span.Start, taskStatus.Tables[tableID].SpanStart) &&
+					bytes.Equal(span.End, taskStatus.Tables[tableID].SpanEnd) {
+					shouldUpdateState = false
+					continue
+				}
+				taskStatus.Tables[tableID] = &model.TableReplicaInfo{
+					SpanStart: span.Start,
+					SpanEnd:   span.End,
+					StartTs:   globalCheckpointTs,
+				}
+				log.Info("rebalance",
+					zap.String("capture-id", captureID),
+					zap.Int64("table-id", tableID),
+					zap.String("span", span.String()))
+			} else if _, ok := taskStatus.Tables[tableID]; ok {
+				// if cpature not allocate span, remove this table
+				s.state.PatchTaskStatus(captureID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
+					if status == nil {
+						// the capture may be down, just skip remove this table
+						return status, false, nil
+					}
+					if status.Operation != nil && status.Operation[tableID] != nil {
+						// skip remove this table to avoid the remove operation created by rebalance function to influence the operation created by other function
+						return status, false, nil
+					}
+					status.RemoveTable(tableID, s.state.Status.CheckpointTs, false)
+					log.Info("Rebalance: Move table",
+						zap.Int64("table-id", tableID),
+						zap.String("capture", captureID),
+						zap.String("changefeed-id", s.state.ID))
+					return status, true, nil
+				})
+			}
+
+		}
+	}
+
+	for captureID, _ := range s.state.TaskStatuses {
+		s.state.PatchTaskStatus(captureID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
+			if status == nil {
+				// the capture may be down, just skip remove this table
+				return status, false, nil
+			}
+			return status, true, nil
+		})
+
+	}
+	return
+}
+
+func (s *scheduler) divideRegionsByCaptureNum(
+	regions []*tikv.Region,
+	tableSpan regionspan.Span) map[model.CaptureID]regionspan.ComparableSpan {
+	regionNum := len(regions)
+	captureNum := len(s.captures)
+	capture2Span := make(map[model.CaptureID]regionspan.ComparableSpan)
+	upperLimitPerCapture := int(math.Ceil(float64(regionNum) / float64(captureNum)))
+
+	log.Info("divide regions to captures",
+		zap.Int("region num", regionNum),
+		zap.Int("capture num", captureNum),
+	)
+	var start, end []byte
+
+	regionIdx := 0
+	var nextIdx int
+	for captureID := range s.captures {
+		if regionIdx >= regionNum {
+			break
+		}
+		nextIdx = regionIdx + upperLimitPerCapture
+
+		if regionIdx == 0 {
+			start = tableSpan.Start
+		} else {
+			start = regions[regionIdx].StartKey()
+		}
+		if nextIdx >= regionNum {
+			end = tableSpan.End
+		} else {
+			end = regions[nextIdx].StartKey()
+		}
+
+		capture2Span[captureID] = regionspan.ComparableSpan{
+			Start: start,
+			End:   end,
+		}
+		regionIdx = nextIdx
+	}
+	log.Info("divide result",
+		zap.Any("capture2Span", capture2Span))
+	return capture2Span
+}
+
+func GetRegionsByTableID(ctx context.Context, tableID model.TableID, pd pd.Client) ([]*tikv.Region, error) {
+	limit := 1000
+	tikvRequestMaxBackoff := 20000 // Maximum total sleep time(in ms)
+	tableSpan := regionspan.GetTableSpan(tableID)
+	bo := tikv.NewBackoffer(ctx, tikvRequestMaxBackoff)
+
+	regionCache := tikv.NewRegionCache(pd)
+	start := tableSpan.Start
+	end := tableSpan.End
+	var regions []*tikv.Region
+	for {
+		batchRegions, err := regionCache.BatchLoadRegionsWithKeyRange(bo, start, end, tikvRequestMaxBackoff)
+		if err != nil {
+			return nil, cerror.WrapError(cerror.ErrPDBatchLoadRegions, err)
+		}
+		regions = append(regions, batchRegions...)
+		if limit > len(batchRegions) {
+			break
+		}
+		start = batchRegions[len(batchRegions)-1].EndKey()
+	}
+
+	return regions, nil
 }

--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -49,7 +49,11 @@ func (n *pullerNode) tableSpan(ctx cdcContext.Context) []regionspan.Span {
 	// start table puller
 	config := ctx.ChangefeedVars().Info.Config
 	spans := make([]regionspan.Span, 0, 4)
-	spans = append(spans, regionspan.GetTableSpan(n.tableID))
+	if n.replicaInfo.SpanStart == nil || n.replicaInfo.SpanEnd == nil {
+		spans = append(spans, regionspan.GetTableSpan(n.tableID))
+	} else {
+		spans = append(spans, regionspan.Span{Start: n.replicaInfo.SpanStart, End: n.replicaInfo.SpanEnd})
+	}
 
 	if config.Cyclic.IsEnabled() && n.replicaInfo.MarkTableID != 0 {
 		spans = append(spans, regionspan.GetTableSpan(n.replicaInfo.MarkTableID))

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -136,7 +136,7 @@ func (p *processor) Tick(ctx cdcContext.Context, state *orchestrator.ChangefeedR
 	} else {
 		code = string(cerror.ErrProcessorUnknown.RFCCode())
 	}
-	state.PatchTaskPosition(p.captureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(p.captureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		if position == nil {
 			position = &model.TaskPosition{}
 		}
@@ -169,6 +169,9 @@ func (p *processor) tick(ctx cdcContext.Context, state *orchestrator.ChangefeedR
 		return nil, errors.Trace(err)
 	}
 	if err := p.handleTableOperation(ctx); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := p.handleKeySpanOperation(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := p.checkTablesNum(ctx); err != nil {
@@ -205,7 +208,7 @@ func (p *processor) checkPosition() (skipThisTick bool) {
 		log.Warn("position is nil, maybe position info is removed unexpected", zap.Any("state", p.changefeed))
 	}
 	checkpointTs := p.changefeed.Info.GetCheckpointTs(p.changefeed.Status)
-	p.changefeed.PatchTaskPosition(p.captureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	p.changefeed.PatchTaskPosition(p.captureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		if position == nil {
 			return &model.TaskPosition{
 				CheckPointTs: checkpointTs,
@@ -441,6 +444,62 @@ func (p *processor) handleTableOperation(ctx cdcContext.Context) error {
 	return nil
 }
 
+// handleTableOperation handles the operation of `TaskStatus`(add table operation and remove table operation)
+func (p *processor) handleKeySpanOperation(ctx cdcContext.Context) error {
+	patchOperation := func(hash model.KeySpanHash, fn func(operation *model.TableOperation) error) {
+		p.changefeed.PatchTaskStatus(p.captureInfo.ID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
+			if status == nil || status.KeySpanOperation == nil {
+				log.Error("KeySpanOperation not found, may be remove by other patch", zap.Uint64("hash", hash), zap.Any("status", status))
+				return nil, false, cerror.ErrTaskStatusNotExists.GenWithStackByArgs()
+			}
+			opt := status.KeySpanOperation[hash]
+			if opt == nil {
+				log.Error("KeySpanOperation not found, may be remove by other patch", zap.Uint64("hash", hash), zap.Any("status", status))
+				return nil, false, cerror.ErrTaskStatusNotExists.GenWithStackByArgs()
+			}
+			if err := fn(opt); err != nil {
+				return nil, false, errors.Trace(err)
+			}
+			return status, true, nil
+		})
+	}
+	taskStatus := p.changefeed.TaskStatuses[p.captureInfo.ID]
+	for hash, opt := range taskStatus.KeySpanOperation {
+		if opt.TableApplied() {
+			continue
+		}
+		// globalCheckpointTs := p.changefeed.Status.CheckpointTs
+		if opt.Delete {
+			// TODO(tiool)
+		} else {
+			switch opt.Status {
+			case model.OperDispatched:
+				replicaInfo, exist := taskStatus.KeySpans[hash]
+				if !exist {
+					return cerror.ErrProcessorTableNotFound.GenWithStack("replicaInfo of KeySpan(%v,%v), hash(%v)", opt.SpanStart, opt.SpanEnd, hash)
+				}
+				if replicaInfo.StartTs != opt.BoundaryTs {
+					log.Warn("the startTs and BoundaryTs of add table operation should be always equaled", zap.Any("replicaInfo", replicaInfo))
+				}
+				span := regionspan.Span{Start: replicaInfo.SpanStart, End: replicaInfo.SpanEnd}
+				err := p.addKeySpan(ctx, span, hash, replicaInfo)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				patchOperation(hash, func(operation *model.TableOperation) error {
+					operation.Status = model.OperProcessed
+					return nil
+				})
+			case model.OperProcessed:
+				// TODO(tiool)
+			default:
+				log.Panic("unreachable")
+			}
+		}
+	}
+	return nil
+}
+
 func (p *processor) createAndDriveSchemaStorage(ctx cdcContext.Context) (entry.SchemaStorage, error) {
 	kvStorage := ctx.GlobalVars().KVStorage
 	ddlspans := []regionspan.Span{regionspan.GetDDLSpan(), regionspan.GetAddIndexDDLSpan()}
@@ -594,7 +653,7 @@ func (p *processor) handlePosition() {
 	// minResolvedTs and minCheckpointTs may less than global resolved ts and global checkpoint ts when a new table added, the startTs of the new table is less than global checkpoint ts.
 	if minResolvedTs != p.changefeed.TaskPositions[p.captureInfo.ID].ResolvedTs ||
 		minCheckpointTs != p.changefeed.TaskPositions[p.captureInfo.ID].CheckPointTs {
-		p.changefeed.PatchTaskPosition(p.captureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+		p.changefeed.PatchTaskPosition(p.captureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			failpoint.Inject("ProcessorUpdatePositionDelaying", nil)
 			if position == nil {
 				// when the captureInfo is deleted, the old owner will delete task status, task position, task workload in non-atomic
@@ -666,6 +725,12 @@ func (p *processor) addTable(ctx cdcContext.Context, tableID model.TableID, repl
 		return errors.Trace(err)
 	}
 	p.tables[tableID] = table
+	return nil
+}
+
+func (p *processor) addKeySpan(ctx cdcContext.Context, span regionspan.Span, hash model.KeySpanHash, replicaInfo *model.TableReplicaInfo) error {
+	log.Info("processor.addKeySpan", zap.String("span", span.String()), zap.Uint64("hash", hash), zap.Any("replicaInfo", replicaInfo))
+	// TODO(tiool)
 	return nil
 }
 

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -192,7 +192,7 @@ func (s *processorSuite) TestHandleTableOperation4SingleTable(c *check.C) {
 		status.ResolvedTs = 100
 		return status, true, nil
 	})
-	p.changefeed.PatchTaskPosition(p.captureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	p.changefeed.PatchTaskPosition(p.captureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		position.ResolvedTs = 100
 		return position, true, nil
 	})
@@ -325,7 +325,7 @@ func (s *processorSuite) TestHandleTableOperation4MultiTable(c *check.C) {
 		status.ResolvedTs = 20
 		return status, true, nil
 	})
-	p.changefeed.PatchTaskPosition(p.captureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	p.changefeed.PatchTaskPosition(p.captureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		position.ResolvedTs = 100
 		position.CheckPointTs = 90
 		return position, true, nil
@@ -679,7 +679,7 @@ func (s *processorSuite) TestPositionDeleted(c *check.C) {
 	})
 
 	// some other delete the task position
-	p.changefeed.PatchTaskPosition(p.captureInfo.ID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	p.changefeed.PatchTaskPosition(p.captureInfo.ID, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		return nil, true, nil
 	})
 	tester.MustApplyPatches()

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/shopspring/decimal v1.3.0
 	github.com/soheilhy/cmux v0.1.5
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0

--- a/pkg/etcd/etcdkey.go
+++ b/pkg/etcd/etcdkey.go
@@ -15,6 +15,7 @@ package etcd
 
 import (
 	"log"
+	"strconv"
 	"strings"
 
 	cerror "github.com/pingcap/ticdc/pkg/errors"
@@ -79,10 +80,11 @@ type CDCKey struct {
 	ChangefeedID string
 	CaptureID    string
 	OwnerLeaseID string
+	KeySpanHash  uint64
 }
 
 // Parse parses the given etcd key
-func (k *CDCKey) Parse(key string) error {
+func (k *CDCKey) Parse(key string) (err error) {
 	if !strings.HasPrefix(key, EtcdKeyBase) {
 		return cerror.ErrInvalidEtcdKey.GenWithStackByArgs(key)
 	}
@@ -122,13 +124,18 @@ func (k *CDCKey) Parse(key string) error {
 		k.ChangefeedID = splitKey[1]
 		k.OwnerLeaseID = ""
 	case strings.HasPrefix(key, taskPositionKey):
-		splitKey := strings.SplitN(key[len(taskPositionKey)+1:], "/", 2)
-		if len(splitKey) != 2 {
+		splitKey := strings.SplitN(key[len(taskPositionKey)+1:], "/", 3)
+		if len(splitKey) < 2 {
 			return cerror.ErrInvalidEtcdKey.GenWithStackByArgs(key)
 		}
 		k.Tp = CDCKeyTypeTaskPosition
 		k.CaptureID = splitKey[0]
 		k.ChangefeedID = splitKey[1]
+		if len(splitKey) > 2 {
+			if k.KeySpanHash, err = strconv.ParseUint(splitKey[2], 10, 64); err != nil {
+				return cerror.ErrInvalidEtcdKey.GenWithStackByArgs(key)
+			}
+		}
 		k.OwnerLeaseID = ""
 	case strings.HasPrefix(key, taskWorkloadKey):
 		splitKey := strings.SplitN(key[len(taskWorkloadKey)+1:], "/", 2)
@@ -161,6 +168,9 @@ func (k *CDCKey) String() string {
 	case CDCKeyTypeTaskPosition:
 		return EtcdKeyBase + taskPositionKey + "/" + k.CaptureID + "/" + k.ChangefeedID
 	case CDCKeyTypeTaskStatus:
+		if k.KeySpanHash != 0 {
+			return EtcdKeyBase + taskStatusKey + "/" + k.CaptureID + "/" + k.ChangefeedID + "/" + strconv.FormatUint(k.KeySpanHash, 10)
+		}
 		return EtcdKeyBase + taskStatusKey + "/" + k.CaptureID + "/" + k.ChangefeedID
 	case CDCKeyTypeTaskWorkload:
 		return EtcdKeyBase + taskWorkloadKey + "/" + k.CaptureID + "/" + k.ChangefeedID

--- a/pkg/orchestrator/reactor_state_test.go
+++ b/pkg/orchestrator/reactor_state_test.go
@@ -401,13 +401,13 @@ func (s *stateSuite) TestPatchTaskPosition(c *check.C) {
 	stateTester := NewReactorStateTester(c, state, nil)
 	captureID1 := "capture1"
 	captureID2 := "capture2"
-	state.PatchTaskPosition(captureID1, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID1, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		c.Assert(position, check.IsNil)
 		return &model.TaskPosition{
 			CheckPointTs: 1,
 		}, true, nil
 	})
-	state.PatchTaskPosition(captureID2, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID2, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		c.Assert(position, check.IsNil)
 		return &model.TaskPosition{
 			CheckPointTs: 2,
@@ -422,11 +422,11 @@ func (s *stateSuite) TestPatchTaskPosition(c *check.C) {
 			CheckPointTs: 2,
 		},
 	})
-	state.PatchTaskPosition(captureID1, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID1, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		position.CheckPointTs = 3
 		return position, true, nil
 	})
-	state.PatchTaskPosition(captureID2, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID2, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		position.ResolvedTs = 2
 		return position, true, nil
 	})
@@ -440,13 +440,13 @@ func (s *stateSuite) TestPatchTaskPosition(c *check.C) {
 			ResolvedTs:   2,
 		},
 	})
-	state.PatchTaskPosition(captureID1, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID1, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		return nil, false, nil
 	})
-	state.PatchTaskPosition(captureID2, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID2, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		return nil, true, nil
 	})
-	state.PatchTaskPosition(captureID1, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+	state.PatchTaskPosition(captureID1, 0, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 		position.Count = 6
 		return position, true, nil
 	})

--- a/pkg/regionspan/span.go
+++ b/pkg/regionspan/span.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/spaolacci/murmur3"
 	"go.uber.org/zap"
 )
 
@@ -35,6 +36,16 @@ type Span struct {
 // String returns a string that encodes Span in hex format.
 func (s Span) String() string {
 	return fmt.Sprintf("[%s, %s)", hex.EncodeToString(s.Start), hex.EncodeToString(s.End))
+}
+
+var HASH_SEP = []byte{0x0}
+
+func (s Span) Hash() uint64 {
+	hasher := murmur3.New64()
+	hasher.Write(s.Start)
+	hasher.Write(HASH_SEP)
+	hasher.Write(s.End)
+	return hasher.Sum64()
 }
 
 // UpperBoundKey represents the maximum value.


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

Initial commit of capture. PTAL~ @dengqee @tongtongyin @zeminzhou 

@dengqee PTAL scheduler related: 1. [workload](https://github.com/pingyu/tioolman/compare/capture-init?expand=1#diff-068a68ea67f22d3df072df08f0b6ecb8bc987df2675c4391b2ffea5074283527R182), 2. [split jobs](https://github.com/pingyu/tioolman/compare/capture-init?expand=1#diff-068a68ea67f22d3df072df08f0b6ecb8bc987df2675c4391b2ffea5074283527R244)

@zeminzhou PTAL [Processor.addKeySpan](https://github.com/pingyu/tioolman/compare/capture-init?expand=1#diff-55a9a4424fd834ec23f010504e478b5b98b36ad6c267c3807dbb36bd433fd3a5R733)

@tongtongyin Would you like to take a look at other *TODO*s, and pick any one of them ? (e.g. [OperProcessed](https://github.com/pingyu/tioolman/compare/capture-init?expand=1#diff-55a9a4424fd834ec23f010504e478b5b98b36ad6c267c3807dbb36bd433fd3a5R494))

## What's changed
打通 Owner -> Scheduler -> Capture -> Processor
Mock 了一个最基本的调度，现在 create table 的时候可以把整个 table 的 key span 带给 `Processor.addKeySpan`
